### PR TITLE
Support for video params from mediaType object of request bid

### DIFF
--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -1080,7 +1080,7 @@ export const spec = {
       bid = deepClone(originalBid);
       bid.params.adSlot = bid.params.adSlot || '';
       _parseAdSlot(bid);
-      if (bid.params.hasOwnProperty('video')) {
+      if (bid.mediaTypes.hasOwnProperty('video') || bid.params.hasOwnProperty('video')) {
         // Nothing to do
       } else {
         // If we have a native mediaType configured alongside banner, its ok if the banner size is not set in width and height

--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -1080,7 +1080,7 @@ export const spec = {
       bid = deepClone(originalBid);
       bid.params.adSlot = bid.params.adSlot || '';
       _parseAdSlot(bid);
-      if (bid.mediaTypes.hasOwnProperty('video') || bid.params.hasOwnProperty('video')) {
+      if ((bid.mediaTypes && bid.mediaTypes.hasOwnProperty('video')) || bid.params.hasOwnProperty('video')) {
         // Nothing to do
       } else {
         // If we have a native mediaType configured alongside banner, its ok if the banner size is not set in width and height

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -3861,4 +3861,44 @@ describe('PubMatic adapter', function () {
       })
     });
   });
+
+  describe('Video request params', function() {
+    let sandbox, utilsMock, newVideoRequest;
+    beforeEach(() => {
+      utilsMock = sinon.mock(utils);
+      sandbox = sinon.sandbox.create();
+      sandbox.spy(utils, 'logWarn');
+      newVideoRequest = utils.deepClone(videoBidRequests)
+    });
+
+    afterEach(() => {
+      utilsMock.restore();
+      sandbox.restore();
+    })
+
+    it('Should log warning if video params from mediaTypes and params obj of bid are not present', function () {
+      delete newVideoRequest[0].mediaTypes.video;
+      delete newVideoRequest[0].params.video;
+
+      let request = spec.buildRequests(newVideoRequest, {
+        auctionId: 'new-auction-id'
+      });
+
+      sinon.assert.calledOnce(utils.logWarn);
+      expect(request).to.equal(undefined);
+    });
+
+    it('Should consider video params from mediaType object of bid', function () {
+      delete newVideoRequest[0].params.video;
+
+      let request = spec.buildRequests(newVideoRequest, {
+        auctionId: 'new-auction-id'
+      });
+      let data = JSON.parse(request.data);
+      expect(data.imp[0].video).to.exist;
+      expect(data.imp[0]['video']['w']).to.equal(videoBidRequests[0].mediaTypes.video.playerSize[0]);
+      expect(data.imp[0]['video']['h']).to.equal(videoBidRequests[0].mediaTypes.video.playerSize[1]);
+      expect(data.imp[0]['video']['battr']).to.equal(undefined);
+    });
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Added support to consider video params from mediaTypes object of requested bid, along with params object of the request bid.
<!-- For new bidder adapters, please provide the following -->
