### PR TITLE
Added miltibid support for GroupM

### DIFF
--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -1065,6 +1065,12 @@ export const spec = {
    * @return ServerRequest Info describing the request to the server.
    */
   buildRequests: (validBidRequests, bidderRequest) => {
+    if (bidderRequest && bidderRequest.bidderCode === GROUPM_ALIAS.code) {
+      // We have got the buildRequests function call for GroupM
+      logInfo('For all publishers using GroupM bidder, the PubMatic bidder will also be enabled so PubMatic server will respond back with the bids that needs to be submitted for PubMatic and GroupM in the network call sent by PubMatic bidder. Hence we do not want to create a network call for GroupM. This way we are trying to save a network call from browser.');
+      return;
+    }
+
     var refererInfo;
     if (bidderRequest && bidderRequest.refererInfo) {
       refererInfo = bidderRequest.refererInfo;
@@ -1285,6 +1291,13 @@ export const spec = {
                 newBid.adserverTargeting = {
                   'hb_buyid_pubmatic': seatbidder.ext.buyid
                 };
+              }
+
+              // if from the server-response the bid.ext.marketplace is set then
+              //    submit the bid to Prebid as marketplace name
+              if (bid.ext && !!bid.ext.marketplace) {
+                newBid.bidderCode = bid.ext.marketplace;
+                newBid.bidder = bid.ext.marketplace;
               }
 
               bidResponses.push(newBid);

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -3901,4 +3901,40 @@ describe('PubMatic adapter', function () {
       expect(data.imp[0]['video']['battr']).to.equal(undefined);
     });
   });
+
+  describe('GroupM params', function() {
+    let sandbox, utilsMock, newBidRequests, newBidResponses;
+    beforeEach(() => {
+      utilsMock = sinon.mock(utils);
+      sandbox = sinon.sandbox.create();
+      sandbox.spy(utils, 'logInfo');
+      newBidRequests = utils.deepClone(bidRequests)
+      newBidRequests[0].bidder = 'groupm';
+      newBidResponses = utils.deepClone(bidResponses);
+      newBidResponses.body.seatbid[0].bid[0].ext.marketplace = 'groupm'
+    });
+
+    afterEach(() => {
+      utilsMock.restore();
+      sandbox.restore();
+    })
+
+    it('Should log info when bidder is groupm  and return', function () {
+      let request = spec.buildRequests(newBidRequests, {bidderCode: 'groupm',
+        auctionId: 'new-auction-id'
+      });
+      sinon.assert.calledOnce(utils.logInfo);
+      expect(request).to.equal(undefined);
+    });
+
+    it('Should add bidder code & bidder as groupm for marketplace groupm response', function () {
+      let request = spec.buildRequests(newBidRequests, {
+        auctionId: 'new-auction-id'
+      });
+      let response = spec.interpretResponse(newBidResponses, request);
+      expect(response).to.be.an('array').with.length.above(0);
+      expect(response[0].bidderCode).to.equal('groupm');
+      expect(response[0].bidder).to.equal('groupm');
+    });
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
